### PR TITLE
fix: problem matcher path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Register Deno problem matchers
       shell: bash
-      run: echo "::add-matcher::.github/deno-matcher.json"
+      run: echo "::add-matcher::${{ github.action_path }}/.github/deno-matcher.json"
 
     - name: Cache Deno dependencies
       id: cache-deno


### PR DESCRIPTION
fixes the action failing with

```
Unable to process command '::add-matcher::.github/deno-matcher.json' successfully.
Could not find file '/home/runner/work/${ORG}/${REPO}/.github/deno-matcher.json'.
```

See https://github.com/catppuccin/userstyles/pull/407