### PR TITLE
build: bump actions to latest version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Setup Deno
       id: setup-deno
-      uses: denoland/setup-deno@v1.1.3
+      uses: denoland/setup-deno@v1.1.4
       with:
         deno-version: ${{ inputs.deno-version }}
       
@@ -48,7 +48,7 @@ runs:
 
     - name: Cache Deno dependencies
       id: cache-deno
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4.0.0
       with:
         key: ${{ hashFiles(inputs.deno-lock-path) }}
         path: ${{ env.DENO_DIR }}


### PR DESCRIPTION
Node.js v16 is now EOL, and GitHub Actions provides a warning when it or actions with it are used.

![image](https://github.com/nekowinston/setup-deno/assets/47499684/0f5b7d55-2b7d-4eeb-abc8-cf053682d954)

This PR bumps `denoland/setup-deno` to `v1.1.4`, [where Node.js was upgraded to 20](https://github.com/denoland/setup-deno/pull/57), and bumps `actions/cache` to `v4.0.0`, [where Node.js was also upgraded to 20](https://github.com/actions/cache/releases/tag/v4.0.0) (among two other small and non-breaking changes).
